### PR TITLE
Fix About Me navbar active state

### DIFF
--- a/about_us.html
+++ b/about_us.html
@@ -51,12 +51,12 @@
         <div class="collapse navbar-collapse" id="navbarSupportedContent">
           <ul class="navbar-nav m-auto">
             <li class="nav-item">
-              <a class="nav-link active text_hover_animaiton" href="index.html"
+              <a class="nav-link text_hover_animaiton" href="index.html"
                 >Home
               </a>
             </li>
             <li class="nav-item">
-              <a class="nav-link text_hover_animaiton" href="about_us.html"
+              <a class="nav-link active text_hover_animaiton" href="about_us.html"
                 >About Me</a
               >
             </li>


### PR DESCRIPTION
## Summary
- ensure the About Me page highlights the About Me menu item instead of Home

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685e5ea126f483218067500181996fdb