### PR TITLE
Fix horizontal scrolling issue

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -84,6 +84,10 @@ span {
   margin: 0;
 }
 
+html {
+  overflow-x: hidden;
+}
+
 body {
   overflow-x: hidden;
   scroll-behavior: smooth;
@@ -2770,7 +2774,7 @@ body.loaded {
 .preloader svg {
   position: absolute;
   top: 0;
-  width: 100vw;
+  width: 100%;
   height: 110vh;
   fill: #1a1a1a;
 }


### PR DESCRIPTION
## Summary
- prevent horizontal overflow by disabling `overflow-x` on `html`
- fix preloader SVG width to avoid overshoot

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68652a92399083219b7827a2f15c61d5